### PR TITLE
🐛 Fix: refresh error

### DIFF
--- a/src/components/pages/admin/seats/EditDrawer/UserSelect.tsx
+++ b/src/components/pages/admin/seats/EditDrawer/UserSelect.tsx
@@ -3,7 +3,7 @@ import useClickOutside from "@/hooks/useClickOutside";
 import { getUserListData } from "@/lib/api/amplify/user";
 import ArrowDown from "@public/icons/icon-arrow-down.svg";
 import SearchIcon from "@public/icons/icon-search.svg";
-import { useSuspenseQuery } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import clsx from "clsx";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useFormContext } from "react-hook-form";
@@ -25,7 +25,7 @@ export default function UserSelect() {
     },
   });
 
-  const { data: usersResponse } = useSuspenseQuery({
+  const { data: usersResponse } = useQuery({
     // 전체, 가나다순 정렬
     queryKey: ["memberList", 0, "alphabetical"],
     queryFn: () => getUserListData("0", "alphabetical"),
@@ -67,7 +67,7 @@ export default function UserSelect() {
           className={clsx({ "text-gray-100-opacity-50": !selectedParticipant })}
         >
           {selectedParticipant
-            ? usersResponse.find((user) => user.id === selectedParticipant)
+            ? usersResponse?.find((user) => user.id === selectedParticipant)
                 ?.username || "참여자를 선택해주세요"
             : "참여자를 선택해주세요"}
         </span>

--- a/src/components/pages/admin/seats/hooks/useGetAllSeatsData.ts
+++ b/src/components/pages/admin/seats/hooks/useGetAllSeatsData.ts
@@ -1,6 +1,6 @@
 import { getSeatValidReservationList } from "@/lib/api/amplify/reservation";
 import { getSeatResourceListByResourceStatus } from "@/lib/api/amplify/resource";
-import { useSuspenseQuery } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { useEffect, useState } from "react";
 
 import { SeatData } from "../types";
@@ -37,7 +37,7 @@ export default function useGetAllSeatsData() {
     initializeAllSeatsData(),
   );
 
-  const { data } = useSuspenseQuery({
+  const { data } = useQuery({
     queryKey: ["seats-admin"],
     queryFn: async () => {
       const [

--- a/src/components/pages/meeting-rooms/hooks/useGetReservations.ts
+++ b/src/components/pages/meeting-rooms/hooks/useGetReservations.ts
@@ -2,7 +2,7 @@ import { getReservationListByResourceType } from "@/lib/api/amplify/reservation"
 import { getResourceList } from "@/lib/api/amplify/resource";
 import { getTeamListData } from "@/lib/api/amplify/team";
 import { getUserListData } from "@/lib/api/amplify/user";
-import { useSuspenseQueries } from "@tanstack/react-query";
+import { useQueries } from "@tanstack/react-query";
 import { useAtomValue } from "jotai";
 
 import pickedDateAtom from "../context/pickedDate";
@@ -15,7 +15,7 @@ export const useGetReservations = () => {
     { data: roomReservations },
     { data: users },
     { data: teams },
-  ] = useSuspenseQueries({
+  ] = useQueries({
     queries: [
       {
         queryKey: ["roomList", pickedDate],

--- a/src/components/pages/seats/hooks/useGetAllSeatsData.ts
+++ b/src/components/pages/seats/hooks/useGetAllSeatsData.ts
@@ -1,7 +1,7 @@
 import { getSeatReservationListByDate } from "@/lib/api/amplify/reservation";
 import { getSeatResourceListByResourceStatus } from "@/lib/api/amplify/resource";
 import { userAtom } from "@/store/authUserAtom";
-import { useSuspenseQuery } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { useAtomValue, useSetAtom } from "jotai";
 import { useEffect, useState } from "react";
 
@@ -44,7 +44,7 @@ export default function useGetAllSeatsData() {
   const userData = useAtomValue(userAtom);
   const setMySeatInfo = useSetAtom(mySeatInfoAtom);
 
-  const { data } = useSuspenseQuery({
+  const { data } = useQuery({
     queryKey: ["seats", pickedDate],
     queryFn: async () => {
       const [

--- a/src/lib/api/amplify/helper.ts
+++ b/src/lib/api/amplify/helper.ts
@@ -1,10 +1,13 @@
+import { createServerRunner } from "@aws-amplify/adapter-nextjs";
 import { Amplify } from "aws-amplify";
 import { generateClient } from "aws-amplify/data";
 
 import { type Schema } from "../../../../amplify/data/resource";
 import outputs from "../../../../amplify_outputs.json";
 
-Amplify.configure(outputs);
+Amplify.configure(outputs, {
+  ssr: true,
+});
 
 export type AmplifyResponseType<T> = {
   data: T;
@@ -34,3 +37,7 @@ export type ResourceType = Schema["Resource"]["type"]["resourceType"];
 
 export const RESERVATION_STATUS = client.enums.ReservationStatus.values();
 export type ReservationStatus = (typeof RESERVATION_STATUS)[number];
+
+export const { runWithAmplifyServerContext } = createServerRunner({
+  config: outputs,
+});

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -11,7 +11,9 @@ import type { AppProps } from "next/app";
 import { useRouter } from "next/router";
 import { useState } from "react";
 
-Amplify.configure(outputs);
+Amplify.configure(outputs, { ssr: true });
+
+const AUTH_PATHS = ["/sign-in", "/find-password"];
 
 export default function App({ Component, pageProps }: AppProps) {
   const router = useRouter();
@@ -28,14 +30,12 @@ export default function App({ Component, pageProps }: AppProps) {
       }),
   );
 
-  const isSignInPage = router.pathname === "/sign-in";
-
   return (
     <QueryClientProvider client={queryClient}>
       <ToastProvider />
       <MobileSizeWatcher />
       <ModalProvider />
-      {isSignInPage ? (
+      {AUTH_PATHS.includes(router.pathname) ? (
         <Component {...pageProps} />
       ) : (
         <Layout>


### PR DESCRIPTION
새로고침 할 때마다 `NoValidAuthTokens: No federated jwt` 에러가 나는 문제를 고쳤습니다.

useSuspenseQuery를 쓴 컴포넌트에서 새로고침을 할 경우 에러가 발생하는데,

임시방편으로 useQuery로 모두 바꿨어요.

정확한 이유는 마이그레이션 다 한 이후에 살펴볼게요..

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 서버 사이드 렌더링 지원을 위한 Amplify 구성 업데이트.
	- 인증 관련 경로를 처리하는 로직 개선.

- **버그 수정**
	- 사용자 선택 컴포넌트에서 선택된 참가자의 사용자 이름 표시 로직 강화.

- **문서화**
	- `runWithAmplifyServerContext` 메서드 추가로 서버 측 작업 지원.

- **리팩토링**
	- 여러 데이터 가져오기 훅에서 `useSuspenseQuery`를 `useQuery`로 변경하여 데이터 가져오기 방식 개선.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->